### PR TITLE
docs(examples): default to GITHUB_TOKEN, make the dry-run preview optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,66 +31,92 @@ Superadmins of the Windmill instance can approve resource types, scripts, flows,
 
 You can use the [hub cli](https://www.npmjs.com/package/@windmill-labs/hub-cli) to pull scripts locally from the official Windmill hub and push them to your private hub.
 
-## PR-gated approval (GitHub)
+## Hub ↔ GitHub sync (approval workflows)
 
-Instead of approving scripts only from the hub UI, you can review them as GitHub
-pull requests: **a script created on the hub opens a PR in a content repo, and
-merging the PR approves it on the hub.** Example workflows are in
-[`examples/github-workflows`](examples/github-workflows) — copy them into the
-`.github/workflows` of the git repo that holds your `hub/` content (the repo you
-`pull`/`push` with the hub cli). They are kept here as inert templates so they
-don't run in this deployment repo.
+The hub can fire GitHub `repository_dispatch` events when content is created or
+approved, so a **content repo** (the git repo that holds your `hub/` content and
+that you `pull`/`push` with the hub cli) can react. Example workflows live in
+[`examples/github-workflows`](examples/github-workflows) — copy the ones you need
+into that repo's `.github/workflows/`. They are kept here as inert templates so
+they don't run in this deployment repo. Any hub can opt in (unset = disabled).
 
-### How it flows
+### Pick a setup
+
+How you wire the workflows depends on how you curate:
+
+**A. Review every new script as a PR** — _create in UI → review PR → merge → approved._
+A script created on the hub opens a PR in the content repo; merging it approves
+the script on the hub. Best when you want a human gate on every submission **and**
+your hub's pending asks are all things you intend to review.
+Use: `open-pr-on-script-created` + `push-to-hub` + `pull-on-script-approved`
+(+ optional `open-pending-prs` backstop, + optional `test-push-to-hub` preview).
+
+**B. Approve in the UI, just sync to the repo** — _approve in UI → repo catches up._
+No PR per submission. Maintainers approve in the hub UI as usual and the repo
+pulls the approved content. Best when most submissions are **intentionally left
+unapproved** (e.g. a public-facing hub), so a PR per submission would be noise.
+Use: `pull-on-script-approved` only (+ `push-to-hub` if curators also author
+content in the repo and push it).
+The hub still fires `hub-script-created`, but with no listener GitHub just drops
+it (204, no workflow run) — harmless, no error.
+
+### How setup A flows
 
 ```
 create script in hub UI
         │  hub fires repository_dispatch: hub-script-created
         ▼
-open-pr-on-script-created.yaml ──► review PR (test-push-to-hub.yaml comments the impact)
-        │  reviewer merges
+open-pr-on-script-created.yaml ──► review PR  (+ test-push-to-hub.yaml preview, if PR_TOKEN set)
+        │  reviewer reads the diff and merges
         ▼
 push-to-hub.yaml ──► hub-cli push ──► script approved on the hub
 
-# maintainer fast-track (no PR):
+# maintainer fast-track (either setup):
 approve in hub UI ──► hub fires hub-script-approved ──► pull-on-script-approved.yaml ──► commit to main
 ```
 
 ### The workflows
 
-Copy these into your content repo's `.github/workflows/`:
-
-- **`open-pr-on-script-created.yaml`** — triggered by the hub's `hub-script-created`
-  dispatch. Runs `materialize-ask` to write the new script's files and opens (or
-  updates) a review PR on a `hub-submission/script-<ask_id>` branch. This is the
-  real-time path from "created in the UI" to "reviewable PR".
-- **`open-pending-prs.yaml`** — scheduled backstop (every 30 min). Runs
-  `list-pending` and opens a PR for any unapproved script the dispatch missed
-  (GitHub outage, expired token, etc.). Uses the same branch names, so it never
-  double-opens a PR the fast path already created.
-- **`test-push-to-hub.yaml`** — runs on every PR touching `hub/**` (including the
-  submission PRs). A dry-run `push` that comments on the PR what merging will do
-  on the hub. Pure preview — no hub changes.
+- **`open-pr-on-script-created.yaml`** — triggered by `hub-script-created`. Runs
+  `materialize-ask` to write the new script's files and opens/updates a review PR
+  on a `hub-submission/script-<ask_id>` branch. Forward-only — only new creations,
+  never the existing backlog.
+- **`pull-on-script-approved.yaml`** — triggered by `hub-script-approved` (fires
+  only on **UI** approvals; the CLI push approves with `?no_dispatch=true`). Pulls
+  the approved content and commits to `main`; in setup A it also closes the
+  matching review PR if one was open. The event-driven replacement for a polling
+  "update-from-hub" cron.
 - **`push-to-hub.yaml`** — runs on push to `main` touching `hub/**`. Reconciles
   the repo into the hub via `hub-cli push`, which **approves** whatever is in the
-  repo — so merging a submission PR approves that script. This closes the
-  create → PR → merge → approved loop. (Omits `--prune` by default; see the file's
-  header for why under the "keep both approval paths" model.)
-- **`pull-on-script-approved.yaml`** — triggered by the hub's `hub-script-approved`
-  dispatch (fires only on **UI** approvals — the CLI push approves with
-  `?no_dispatch=true`). Pulls the now-approved content into the repo and commits
-  to `main`, and closes the matching review PR if one was open. This is the
-  event-driven replacement for a polling "update-from-hub" cron.
+  repo — so merging a submission PR approves that script. (Omits `--prune` by
+  default; see the file header for why under the "keep both approval paths" model.)
+- **`test-push-to-hub.yaml`** _(optional preview)_ — dry-run `push` that comments
+  on a PR what merging would do on the hub. See "The dry-run preview" below.
+- **`open-pending-prs.yaml`** _(optional backstop — setup A only)_ — scheduled
+  every 30 min. Runs `list-pending` and opens a PR for any unapproved ask the
+  dispatch missed. **Caution:** `list-pending` returns _every_ unapproved ask not
+  already in the repo, so this opens a PR for your entire unapproved backlog. Use
+  it only on a curated hub where "pending == awaiting approval" — **not** on a hub
+  with intentionally-unapproved asks, where it would mass-open PRs.
 
-The two halves work together: `open-*` + `push-to-hub` cover the reviewed path
-(created → PR → merge → approved), while `pull-on-script-approved` covers the
-maintainer fast-track (approve in the UI → repo catches up). `test-push-to-hub`
-gives reviewers a preview on every PR.
+### The dry-run preview (optional)
+
+By default the workflows open PRs with the built-in `GITHUB_TOKEN` and there is
+**no** dry-run preview. You usually don't need one: merging a submission PR just
+**approves the already-existing version** on the hub (the script was created in
+the UI, so its version already exists) — a new version is pushed only if a
+reviewer **edits** the file in the PR, and reviewers read the actual code in the
+PR diff anyway.
+
+To enable the preview, set `secrets.PR_TOKEN` (a PAT/GitHub App token) and add
+`test-push-to-hub.yaml`. The `open-*` workflows open PRs with
+`${{ secrets.PR_TOKEN || secrets.GITHUB_TOKEN }}`, so a PR opened with the PAT can
+trigger `test-push-to-hub` — a PR opened with the default `GITHUB_TOKEN` can't
+trigger other workflows.
 
 ### Configure the hub
 
-Set these on the **hub** service (in `docker-compose.yml` / `.env`) so it
-dispatches events to your content repo (any hub can opt in — unset = disabled):
+Set these on the **hub** service (in `docker-compose.yml` / `.env`):
 
 - `GITHUB_DISPATCH_REPO` — `owner/repo` of your content repo
 - `GITHUB_DISPATCH_TOKEN` — token allowed to create dispatch events (fine-grained
@@ -98,16 +124,18 @@ dispatches events to your content repo (any hub can opt in — unset = disabled)
 
 ### Configure the content repo
 
-In the GitHub repo holding your `hub/` content, set:
+In the GitHub repo holding your `hub/` content:
 
-- `secrets.HUB_TOKEN` — a superadmin token of your Windmill instance
+- `secrets.HUB_TOKEN` — a superadmin token of your Windmill instance _(required)_
+- `vars.HUB_URL` — your hub URL, e.g. `https://hub.example.com` _(required; the
+  examples read `vars.HUB_URL`)_
 - `secrets.LICENSE_KEY` — your enterprise license key (drop it for an unlicensed
   private hub)
-- `secrets.PR_TOKEN` — a PAT/GitHub App token used to **open** the review PRs.
-  Required so those PRs trigger `test-push-to-hub.yaml` (PRs opened with the
-  default `GITHUB_TOKEN` don't trigger other workflows)
-- `vars.HUB_URL` — your hub URL (e.g. `https://hub.example.com`)
+- `secrets.PR_TOKEN` — **optional**, only for the dry-run preview (see above).
+  Without it, PRs open with `GITHUB_TOKEN`, which requires **Settings → Actions →
+  General → Allow GitHub Actions to create and approve pull requests** to be
+  enabled.
 
-Requires `@windmill-labs/hub-cli` recent enough to include the `list-pending` and
-`materialize-ask` commands, and a hub that exposes `latest_version` on
+Requires `@windmill-labs/hub-cli` recent enough to include `list-pending` and
+`materialize-ask`, and a hub that exposes `latest_version` on
 `/searchData?all=true`.

--- a/examples/github-workflows/open-pending-prs.yaml
+++ b/examples/github-workflows/open-pending-prs.yaml
@@ -1,10 +1,15 @@
-# EXAMPLE — PR-gated hub approval (poll backstop).
+# EXAMPLE — PR-gated hub approval (poll backstop). OPTIONAL.
 #
 # open-pr-on-script-created.yaml is the fast path; this is the safety net. On a
 # schedule it asks the hub for unapproved asks that aren't tracked locally yet
 # (list-pending) and opens one review PR per script — catching any dispatch the
 # hub dropped (GitHub outage, token expiry, etc.). Same branch naming as the
 # fast path (hub-submission/script-<ask_id>), so the two never double-open a PR.
+#
+# CAUTION: list-pending returns EVERY unapproved ask not already in the repo, so
+# this opens a PR for your entire unapproved backlog. Use it only on a curated hub
+# where "pending == awaiting approval" — NOT on a hub that intentionally leaves
+# submissions unapproved (e.g. a public-facing hub), where it would mass-open PRs.
 #
 # Requires a hub recent enough to expose `latest_version` on /searchData?all=true
 # (so a pending ask's content can be fetched without the dispatch payload).

--- a/examples/github-workflows/open-pending-prs.yaml
+++ b/examples/github-workflows/open-pending-prs.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Open / update the review PR
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.PR_TOKEN }}
+          token: ${{ secrets.PR_TOKEN || secrets.GITHUB_TOKEN }}
           branch: hub-submission/script-${{ matrix.ask_id }}
           labels: hub-submission
           commit-message: "feat: hub script #${{ matrix.ask_id }}"

--- a/examples/github-workflows/open-pr-on-script-created.yaml
+++ b/examples/github-workflows/open-pr-on-script-created.yaml
@@ -9,13 +9,24 @@
 # Reliability: this is the fast path. open-pending-prs.yaml is the backstop that
 # catches any dropped dispatch.
 #
+# Why there's no dry-run preview by default: merging a hub-submission PR just
+# APPROVES the already-existing script on the hub. The script was created in the
+# UI, so its version already exists — the merge only flips approval; no new
+# version is pushed unless a reviewer EDITS the file in the PR (then push-to-hub
+# creates a version from the edit). Reviewers read the actual code in the PR diff,
+# so the impact comment usually adds nothing. To enable it anyway, set PR_TOKEN.
+#
 # Secrets / variables this expects:
 #   secrets.HUB_TOKEN    superadmin token of your Windmill instance / hub
 #   secrets.LICENSE_KEY  (official hub only) enterprise license key
-#   secrets.PR_TOKEN     a PAT/GitHub App token used to OPEN the PR. Needed so the
-#                        PR triggers test-push-to-hub.yaml — PRs opened with the
-#                        default GITHUB_TOKEN do not trigger other workflows.
 #   vars.HUB_URL         your hub URL (e.g. https://hub.example.com)
+#   secrets.PR_TOKEN     OPTIONAL. PAT/GitHub App token to open the PR. Only needed
+#                        to enable the test-push-to-hub.yaml dry-run preview: a PR
+#                        opened with the default GITHUB_TOKEN can't trigger other
+#                        workflows, so the preview won't run without it. Unset =>
+#                        the PR opens with GITHUB_TOKEN (no preview), which needs
+#                        "Allow GitHub Actions to create and approve pull requests"
+#                        enabled in the repo/org Actions settings.
 name: Open review PR for a hub-created script
 
 on:
@@ -54,7 +65,7 @@ jobs:
       - name: Open / update the review PR
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.PR_TOKEN }}
+          token: ${{ secrets.PR_TOKEN || secrets.GITHUB_TOKEN }}
           branch: hub-submission/script-${{ github.event.client_payload.ask_id }}
           labels: hub-submission
           commit-message: "feat(${{ github.event.client_payload.app }}): ${{ github.event.client_payload.summary }}"

--- a/examples/github-workflows/pull-on-script-approved.yaml
+++ b/examples/github-workflows/pull-on-script-approved.yaml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write # close the redundant review PR (GITHUB_TOKEN path)
 
 concurrency:
   # Same group as push-to-hub.yaml so a pull can't race a curation push.
@@ -64,7 +65,7 @@ jobs:
       - name: Close the now-redundant review PR
         if: github.event_name == 'repository_dispatch'
         env:
-          GH_TOKEN: ${{ secrets.PR_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_TOKEN || secrets.GITHUB_TOKEN }}
           BRANCH: hub-submission/script-${{ github.event.client_payload.ask_id }}
         run: |
           gh pr close "$BRANCH" --delete-branch \

--- a/examples/github-workflows/test-push-to-hub.yaml
+++ b/examples/github-workflows/test-push-to-hub.yaml
@@ -1,9 +1,14 @@
-# EXAMPLE — dry-run + impact comment on PRs touching hub/**.
+# EXAMPLE — OPTIONAL dry-run + impact comment on PRs touching hub/**.
 #
-# Runs on every PR (including the hub-submission PRs opened by
-# open-pr-on-script-created.yaml / open-pending-prs.yaml) so a reviewer sees
-# exactly what merging will do on the hub before approving. Pure dry-run — no
-# hub changes.
+# Off the critical path: the create -> PR -> merge -> approve loop works without
+# it (see open-pr-on-script-created.yaml's "why there's no preview" note). Add
+# this only if you want reviewers to see a summary of what merging will do before
+# approving. Pure dry-run — no hub changes.
+#
+# Note: it fires for the bot-opened hub-submission PRs ONLY if those PRs are
+# opened with a PAT (set secrets.PR_TOKEN) — a PR opened with the default
+# GITHUB_TOKEN can't trigger other workflows. It always runs for human-opened PRs
+# touching hub/**.
 name: Test push to hub (dry run)
 
 on:


### PR DESCRIPTION
Follow-up to the PR-gated approval examples (#2): make the **no-preview** setup the zero-config default.

- Open review PRs with `${{ secrets.PR_TOKEN || secrets.GITHUB_TOKEN }}` — works with no secrets out of the box (no preview); set `PR_TOKEN` later to light up the `test-push-to-hub` dry-run with no edits.
- Document **why** the preview is usually unnecessary: merging a hub-created submission just approves the already-existing version on the hub; a new version is pushed only if a reviewer edits the file in the PR (reviewers read the actual code in the PR diff).
- Add `pull-requests: write` to `pull-on-script-approved` so the redundant-PR close works on the `GITHUB_TOKEN` path.
- Mark `test-push-to-hub` as OPTIONAL and note it only fires for bot PRs when `PR_TOKEN` is set.
- Header now flags the **"Allow GitHub Actions to create and approve pull requests"** repo/org setting needed for the `GITHUB_TOKEN` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)